### PR TITLE
Add ExpressionConverter options

### DIFF
--- a/CrossTypeExpressionConverter.Tests/Units/ExpressionConverterTests.cs
+++ b/CrossTypeExpressionConverter.Tests/Units/ExpressionConverterTests.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using CrossTypeExpressionConverter.Tests.Helpers.Models;
+using CrossTypeExpressionConverter;
 
 namespace CrossTypeExpressionConverter.Tests.Units;
 
@@ -317,6 +318,17 @@ public class ExpressionConverterTests
         Assert.That(ex.Message, Does.Contain(nameof(SourceSimple.PropertyToIgnoreOnDest)));
         Assert.That(ex.Message, Does.Contain("could not be mapped"));
     }
+
+    [Test]
+    public void Convert_MemberMissingOnDestination_NoMap_WithThrowDisabled_ShouldReturnDefault()
+    {
+        Expression<Func<SourceSimple, bool>> sourcePredicate = s => s.PropertyToIgnoreOnDest == "Test";
+        var options = new ExpressionConverterOptions { ThrowOnFailedMemberMapping = false };
+
+        var convertedPredicate = ExpressionConverter.Convert<SourceSimple, DestSimple>(sourcePredicate, null, null, options);
+
+        Assert.IsFalse(Evaluate(convertedPredicate, new DestSimple { Id = 1 }));
+    }
     
     [Test]
     public void Convert_MemberMissingOnDestination_WithMemberMapToNonExistent_ShouldThrowException()
@@ -329,6 +341,18 @@ public class ExpressionConverterTests
         );
         Assert.That(ex.Message, Does.Contain("NonExistentDestProperty"));
         Assert.That(ex.Message, Does.Contain("could not be mapped"));
+    }
+
+    [Test]
+    public void Convert_MemberMissingOnDestination_WithMemberMapToNonExistent_ThrowDisabled_ShouldReturnDefault()
+    {
+        Expression<Func<SourceSimple, bool>> sourcePredicate = s => s.Id == 1;
+        var memberMap = new Dictionary<string, string> { { nameof(SourceSimple.Id), "NonExistentDestProperty" } };
+        var options = new ExpressionConverterOptions { ThrowOnFailedMemberMapping = false };
+
+        var convertedPredicate = ExpressionConverter.Convert<SourceSimple, DestSimple>(sourcePredicate, memberMap, null, options);
+
+        Assert.IsFalse(Evaluate(convertedPredicate, new DestSimple { Id = 1 }));
     }
 
     // --- Parameter Name Test ---

--- a/CrossTypeExpressionConverter.Tests/Units/ExpressionConverterV2Tests.cs
+++ b/CrossTypeExpressionConverter.Tests/Units/ExpressionConverterV2Tests.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using CrossTypeExpressionConverter.Tests.Helpers.Models;
+using CrossTypeExpressionConverter;
 
 namespace CrossTypeExpressionConverter.Tests.Units;
 

--- a/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
+++ b/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
@@ -5,10 +5,10 @@
         <LangVersion>latestmajor</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageVersion>0.2.2</PackageVersion>
-        <Version>0.2.2</Version>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
-        <FileVersion>0.2.2</FileVersion>
+        <PackageVersion>0.3.0</PackageVersion>
+        <Version>0.3.0</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
+        <FileVersion>0.3.0</FileVersion>
         <Authors>Edward S Flores</Authors>
         <Description>Effortlessly translate LINQ predicates across different types (TSource -&gt; TDestination) while maintaining IQueryable compatibility for ORMs like EF Core. Features flexible member mapping: automatic, dictionary-based, or custom delegates.</Description>
         <PackageProjectUrl>https://github.com/scherenhaenden/CrossTypeExpressionConverter</PackageProjectUrl>

--- a/CrossTypeExpressionConverter/ExpressionConverterOptions.cs
+++ b/CrossTypeExpressionConverter/ExpressionConverterOptions.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace CrossTypeExpressionConverter;
+
+/// <summary>
+/// Options to configure the behaviour of <see cref="ExpressionConverter"/>.
+/// </summary>
+public class ExpressionConverterOptions
+{
+    /// <summary>
+    /// If true (default), an <see cref="InvalidOperationException"/> is thrown when
+    /// a source member cannot be mapped to the destination type. If false, the
+    /// converter substitutes <c>default(TMember)</c> for the unmapped member.
+    /// </summary>
+    public bool ThrowOnFailedMemberMapping { get; set; } = true;
+
+    /// <summary>
+    /// Optional validator invoked with the source type before conversion. Can be
+    /// used to enforce custom rules about which models are allowed.
+    /// </summary>
+    public Func<Type, bool>? SourceModelValidator { get; set; }
+
+    /// <summary>
+    /// Optional validator invoked with the destination type before conversion.
+    /// </summary>
+    public Func<Type, bool>? DestinationModelValidator { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.2.1
+Install-Package CrossTypeExpressionConverter -Version 0.3.0
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.2.1
+dotnet add package CrossTypeExpressionConverter --version 0.3.0
 ```
 
 ---
@@ -209,9 +209,9 @@ This would convert `complexFilter` to `d => d.CalculationResult > 10`.
 
 ---
 
-## 🛣️ Roadmap & Future Enhancements (Post v0.2.1)
+## 🛣️ Roadmap & Future Enhancements (Post v0.3.0)
 
-While `CrossTypeExpressionConverter v0.2.1` focuses on robust predicate conversion with flexible mapping, future versions may include:
+While `CrossTypeExpressionConverter v0.3.0` adds a configuration object with basic error handling options, future versions may include:
 
 * ExpressionConverterOptions Object: Introduce a dedicated options class to simplify the Convert method signature and allow for more configuration points (e.g., ThrowOnFailedMemberMapping toggle, case-sensitivity options for name matching).
 * Selector Conversion: Support for converting projection expressions (e.g., Expression<Func<TSource, TResult>> to Expression<Func<TDestination, TDestResult>>).

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,13 +34,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.2.1
+Install-Package CrossTypeExpressionConverter -Version 0.3.0
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.2.1
+dotnet add package CrossTypeExpressionConverter --version 0.3.0
 ```
 
 ---
@@ -190,9 +190,9 @@ This would convert `complexFilter` to `d => d.CalculationResult > 10`.
 
 ---
 
-## 🛣️ Roadmap & Future Enhancements (Post v0.2.1)
+## 🛣️ Roadmap & Future Enhancements (Post v0.3.0)
 
-While `CrossTypeExpressionConverter v0.2.1` focuses on robust predicate conversion with flexible mapping, future versions may include:
+While `CrossTypeExpressionConverter v0.3.0` adds a configuration object with basic error handling options, future versions may include:
 
 * ExpressionConverterOptions Object: Introduce a dedicated options class to simplify the Convert method signature and allow for more configuration points (e.g., ThrowOnFailedMemberMapping toggle, case-sensitivity options for name matching).
 * Selector Conversion: Support for converting projection expressions (e.g., Expression<Func<TSource, TResult>> to Expression<Func<TDestination, TDestResult>>).


### PR DESCRIPTION
## Summary
- add `ExpressionConverterOptions` with error handling and validation hooks
- support the options in `ExpressionConverter`
- bump library version to 0.3.0
- document the new version in README files
- test configurable error handling

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685575db4c6083338e0e29ca2a1a65a6


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Add a configuration object for ExpressionConverter to customize error handling and model validation, propagate options through the converter, update version to 0.3.0, and adjust documentation and tests accordingly.

New Features:
- Introduce ExpressionConverterOptions class with ThrowOnFailedMemberMapping, SourceModelValidator, and DestinationModelValidator.

Enhancements:
- Extend ExpressionConverter.Convert to accept options and enforce validation hooks.
- Allow non-throwing behavior on failed member mappings by returning default values based on options.

Documentation:
- Bump package version to 0.3.0 and update README and docs with new options description.

Tests:
- Add unit tests to verify behavior when ThrowOnFailedMemberMapping is disabled.