### PR TITLE
Add configurable options and error handling

### DIFF
--- a/CrossTypeExpressionConverter.Tests/Units/ExpressionConverterTests.cs
+++ b/CrossTypeExpressionConverter.Tests/Units/ExpressionConverterTests.cs
@@ -324,11 +324,24 @@ public class ExpressionConverterTests
         Expression<Func<SourceSimple, bool>> sourcePredicate = s => s.Id == 1;
         var memberMap = new Dictionary<string, string> { { nameof(SourceSimple.Id), "NonExistentDestProperty" } };
 
-        var ex = Assert.Throws<InvalidOperationException>(() => 
+        var ex = Assert.Throws<InvalidOperationException>(() =>
             ExpressionConverter.Convert<SourceSimple, DestSimple>(sourcePredicate, memberMap)
         );
         Assert.That(ex.Message, Does.Contain("NonExistentDestProperty"));
         Assert.That(ex.Message, Does.Contain("could not be mapped"));
+    }
+
+    [Test]
+    public void Convert_MemberMissingOnDestination_WithIgnoreErrorHandling_ShouldNotThrow()
+    {
+        Expression<Func<SourceSimple, bool>> sourcePredicate = s => s.PropertyToIgnoreOnDest == "Test";
+        var options = new ExpressionConverterOptions { ErrorHandling = MemberMappingErrorHandling.Ignore };
+
+        // Should not throw
+        var converted = ExpressionConverter.Convert<SourceSimple, DestSimple>(sourcePredicate, options);
+
+        // Because the missing property is ignored, the resulting predicate always evaluates to default(bool) => false
+        Assert.IsFalse(Evaluate(converted, new DestSimple { Id = 1 }));
     }
 
     // --- Parameter Name Test ---

--- a/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
+++ b/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
@@ -5,10 +5,10 @@
         <LangVersion>latestmajor</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageVersion>0.2.2</PackageVersion>
-        <Version>0.2.2</Version>
-        <AssemblyVersion>0.2.2</AssemblyVersion>
-        <FileVersion>0.2.2</FileVersion>
+        <PackageVersion>0.3.0</PackageVersion>
+        <Version>0.3.0</Version>
+        <AssemblyVersion>0.3.0</AssemblyVersion>
+        <FileVersion>0.3.0</FileVersion>
         <Authors>Edward S Flores</Authors>
         <Description>Effortlessly translate LINQ predicates across different types (TSource -&gt; TDestination) while maintaining IQueryable compatibility for ORMs like EF Core. Features flexible member mapping: automatic, dictionary-based, or custom delegates.</Description>
         <PackageProjectUrl>https://github.com/scherenhaenden/CrossTypeExpressionConverter</PackageProjectUrl>

--- a/CrossTypeExpressionConverter/ExpressionConverterOptions.cs
+++ b/CrossTypeExpressionConverter/ExpressionConverterOptions.cs
@@ -1,0 +1,46 @@
+namespace CrossTypeExpressionConverter;
+
+/// <summary>
+/// Options controlling the behaviour of <see cref="ExpressionConverter"/>.
+/// Additional options will be added in future versions.
+/// </summary>
+public class ExpressionConverterOptions
+{
+    /// <summary>
+    /// How missing member mappings are handled during conversion.
+    /// </summary>
+    public MemberMappingErrorHandling ErrorHandling { get; set; } = MemberMappingErrorHandling.Throw;
+
+    /// <summary>
+    /// Optional mapping of source member names to destination member names.
+    /// </summary>
+    public IDictionary<string, string>? MemberMap { get; set; }
+
+    /// <summary>
+    /// Optional callback to provide custom expressions for member accesses.
+    /// </summary>
+    public Func<MemberExpression, ParameterExpression, Expression?>? CustomMap { get; set; }
+
+    /// <summary>
+    /// Whether to validate source/destination models before conversion.
+    /// This is a placeholder for future functionality.
+    /// </summary>
+    public bool ValidateModels { get; set; }
+
+    /// <summary>
+    /// Whether to validate custom mapping rules before conversion.
+    /// This is a placeholder for future functionality.
+    /// </summary>
+    public bool ValidateRules { get; set; }
+}
+
+/// <summary>
+/// Specifies how the converter reacts when a member cannot be mapped to the destination type.
+/// </summary>
+public enum MemberMappingErrorHandling
+{
+    /// <summary>Throw an <see cref="InvalidOperationException"/> (default).</summary>
+    Throw,
+    /// <summary>Ignore the missing member and substitute a default value.</summary>
+    Ignore
+}

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.2.1
+Install-Package CrossTypeExpressionConverter -Version 0.3.0
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.2.1
+dotnet add package CrossTypeExpressionConverter --version 0.3.0
 ```
 
 ---
@@ -209,9 +209,9 @@ This would convert `complexFilter` to `d => d.CalculationResult > 10`.
 
 ---
 
-## 🛣️ Roadmap & Future Enhancements (Post v0.2.1)
+## 🛣️ Roadmap & Future Enhancements (Post v0.3.0)
 
-While `CrossTypeExpressionConverter v0.2.1` focuses on robust predicate conversion with flexible mapping, future versions may include:
+While `CrossTypeExpressionConverter v0.3.0` focuses on configurable conversion via `ExpressionConverterOptions`, future versions may include:
 
 * ExpressionConverterOptions Object: Introduce a dedicated options class to simplify the Convert method signature and allow for more configuration points (e.g., ThrowOnFailedMemberMapping toggle, case-sensitivity options for name matching).
 * Selector Conversion: Support for converting projection expressions (e.g., Expression<Func<TSource, TResult>> to Expression<Func<TDestination, TDestResult>>).


### PR DESCRIPTION
## Summary
- introduce `ExpressionConverterOptions` with error handling and future validation flags
- overload `ExpressionConverter.Convert` to accept the new options
- support ignoring unmapped members when configured
- bump package version to `0.3.0` and update docs
- test ignoring unmapped members

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685575db4c6083338e0e29ca2a1a65a6

## Summary by Sourcery

Introduce a new options API for expression conversion, enabling configurable error handling and future validation settings, while supporting an ignore mode for unmapped members and updating versioning and documentation accordingly.

New Features:
- Add ExpressionConverterOptions class with configurable member mapping, custom mapping, error handling, and future validation flags
- Overload ExpressionConverter.Convert to accept an ExpressionConverterOptions parameter
- Introduce MemberMappingErrorHandling enum to control handling of unmapped members and implement ignore behavior

Enhancements:
- Support ignoring unmapped members by returning default values when configured

Documentation:
- Bump package version to 0.3.0 in README and update usage instructions

Tests:
- Add unit test verifying that missing members are ignored without throwing when configured