### PR TITLE
Add tests workflow with coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,28 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+          include-prerelease: true
+      - name: Restore
+        run: dotnet restore
+      - name: Run tests with coverage
+        run: dotnet test --collect:"XPlat Code Coverage" --verbosity normal
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./CrossTypeExpressionConverter.Tests/**/coverage.cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run dotnet tests and upload coverage to Codecov

## Testing
- `dotnet test CrossTypeExpressionConverter.sln --collect:"XPlat Code Coverage" --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685700a55af88333bf17ede8b75479d8

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a GitHub Actions workflow to automatically build, test, and upload code coverage reports on pushes and pull requests to the master and main branches.

### Why are these changes being made?

Automating the build and test processes with coverage metrics ensures code quality is maintained and provides transparency on code coverage in the repository. Using the Codecov action facilitates easy integration for monitoring these metrics, improving the overall development workflow.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->