### PR TITLE
Version/0.5.2

### DIFF
--- a/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
+++ b/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
@@ -5,10 +5,10 @@
         <LangVersion>latestmajor</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageVersion>0.5.1</PackageVersion>
-        <Version>0.5.1</Version>
-        <AssemblyVersion>0.5.1</AssemblyVersion>
-        <FileVersion>0.5.1</FileVersion>
+        <PackageVersion>0.5.2</PackageVersion>
+        <Version>0.5.2</Version>
+        <AssemblyVersion>0.5.2</AssemblyVersion>
+        <FileVersion>0.5.2</FileVersion>
         <Authors>Edward S Flores</Authors>
         <Description>Effortlessly translate LINQ predicates across different types (TSource -&gt; TDestination) while maintaining IQueryable compatibility for ORMs like EF Core. Features flexible member mapping: automatic, dictionary-based, or custom delegates.</Description>
         <PackageProjectUrl>https://github.com/scherenhaenden/CrossTypeExpressionConverter</PackageProjectUrl>

--- a/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
+++ b/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
@@ -5,10 +5,10 @@
         <LangVersion>latestmajor</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageVersion>0.5.0</PackageVersion>
-        <Version>0.5.0</Version>
-        <AssemblyVersion>0.5.0</AssemblyVersion>
-        <FileVersion>0.5.0</FileVersion>
+        <PackageVersion>0.5.1</PackageVersion>
+        <Version>0.5.1</Version>
+        <AssemblyVersion>0.5.1</AssemblyVersion>
+        <FileVersion>0.5.1</FileVersion>
         <Authors>Edward S Flores</Authors>
         <Description>Effortlessly translate LINQ predicates across different types (TSource -&gt; TDestination) while maintaining IQueryable compatibility for ORMs like EF Core. Features flexible member mapping: automatic, dictionary-based, or custom delegates.</Description>
         <PackageProjectUrl>https://github.com/scherenhaenden/CrossTypeExpressionConverter</PackageProjectUrl>

--- a/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
+++ b/CrossTypeExpressionConverter/CrossTypeExpressionConverter.csproj
@@ -23,4 +23,8 @@
         <None Include="../README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    </ItemGroup>
+
 </Project>

--- a/CrossTypeExpressionConverter/ExpressionConverter.cs
+++ b/CrossTypeExpressionConverter/ExpressionConverter.cs
@@ -51,12 +51,6 @@ public sealed class ExpressionConverter : IExpressionConverter
         private readonly ParameterExpression _replaceParam;
         private readonly ExpressionConverterOptions _options;
 
-        private static string? GetAttributeMapping(MemberInfo member)
-        {
-            return _mapsToCache.GetOrAdd(member, static m =>
-                m.GetCustomAttribute<MapsToAttribute>(true)?.DestinationMemberName);
-        }
-
         public Visitor(ParameterExpression replaceParam, ExpressionConverterOptions options)
         {
             _replaceParam = replaceParam;
@@ -116,7 +110,7 @@ public sealed class ExpressionConverter : IExpressionConverter
                 // Precedence 3: [MapsTo] attribute
                 else
                 {
-                    var attrName = GetAttributeMapping(node.Member);
+                    var attrName = MemberMappingCache.GetMapping(node.Member);
                     if (!string.IsNullOrEmpty(attrName))
                     {
                         destMemberName = attrName;

--- a/CrossTypeExpressionConverter/ExpressionConverter.cs
+++ b/CrossTypeExpressionConverter/ExpressionConverter.cs
@@ -51,6 +51,11 @@ public sealed class ExpressionConverter : IExpressionConverter
         private readonly ParameterExpression _replaceParam;
         private readonly ExpressionConverterOptions _options;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Visitor{TSource, TDestination}"/> class for converting expression trees.
+        /// </summary>
+        /// <param name="replaceParam">The parameter expression representing the destination type.</param>
+        /// <param name="options">Options that control expression conversion behavior.</param>
         public Visitor(ParameterExpression replaceParam, ExpressionConverterOptions options)
         {
             _replaceParam = replaceParam;
@@ -75,7 +80,14 @@ public sealed class ExpressionConverter : IExpressionConverter
         /// A new <see cref="MemberExpression"/> pointing to the corresponding member on the destination type,
         /// or a <see cref="DefaultExpression"/> if the member is not found and the error handling is set to <see cref="MemberMappingErrorHandling.ReturnDefault"/>.
         /// </returns>
-        /// <exception cref="InvalidOperationException">Thrown if a member cannot be mapped and error handling is set to <see cref="MemberMappingErrorHandling.Throw"/>.</exception>
+        /// <summary>
+        /// Visits a <see cref="MemberExpression"/> and maps the accessed member from the source type to the destination type according to the configured mapping options.
+        /// </summary>
+        /// <param name="node">The member expression to visit and convert.</param>
+        /// <returns>A new <see cref="MemberExpression"/> accessing the mapped member on the destination type, or a default expression if mapping fails and error handling is set to return default.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if a member cannot be mapped and error handling is set to <see cref="MemberMappingErrorHandling.Throw"/>.
+        /// </exception>
         protected override Expression VisitMember(MemberExpression node)
         {
             // Step 1: Handle custom mapping first, as it has the highest precedence.

--- a/CrossTypeExpressionConverter/MemberMappingCache.cs
+++ b/CrossTypeExpressionConverter/MemberMappingCache.cs
@@ -13,7 +13,11 @@ internal sealed class MemberMappingCache
 
     /// <summary>
     /// Gets the mapped destination member name for a given source member, using the cache.
+    /// <summary>
+    /// Retrieves the destination member name mapped to the specified member, using a cached value if available.
     /// </summary>
+    /// <param name="member">The source member for which to retrieve the mapped destination member name.</param>
+    /// <returns>The destination member name if a mapping exists; otherwise, null.</returns>
     public static string? GetMapping(MemberInfo member)
     {
         return Cache.GetOrAdd(member, static m => 

--- a/CrossTypeExpressionConverter/MemberMappingCache.cs
+++ b/CrossTypeExpressionConverter/MemberMappingCache.cs
@@ -38,6 +38,11 @@ internal static class MemberMappingCache
     public static void PrimeCacheForType(Type type)
     {
         // Use a simple flag in the cache to ensure we only process each type once.
+        if (type.FullName is null)
+        {
+            // Don't prime for types without a name.
+            return;
+        }
         string typeProcessedKey = $"processed_{type.FullName}";
 
         if (!Cache.TryGetValue(typeProcessedKey, out _))

--- a/CrossTypeExpressionConverter/MemberMappingCache.cs
+++ b/CrossTypeExpressionConverter/MemberMappingCache.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace CrossTypeExpressionConverter;
+
+/// <summary>
+/// Provides a thread-safe, static cache for attribute-based member mappings.
+/// This is an internal detail to improve performance by avoiding repeated reflection.
+/// </summary>
+internal sealed class MemberMappingCache
+{
+    private static readonly ConcurrentDictionary<MemberInfo, string?> Cache = new();
+
+    /// <summary>
+    /// Gets the mapped destination member name for a given source member, using the cache.
+    /// </summary>
+    public static string? GetMapping(MemberInfo member)
+    {
+        return Cache.GetOrAdd(member, static m => 
+            m.GetCustomAttribute<MapsToAttribute>(true)?.DestinationMemberName);
+    }
+}

--- a/CrossTypeExpressionConverter/MemberMappingCache.cs
+++ b/CrossTypeExpressionConverter/MemberMappingCache.cs
@@ -1,26 +1,50 @@
-using System.Collections.Concurrent;
+using Microsoft.Extensions.Caching.Memory;
+using System;
 using System.Reflection;
 
 namespace CrossTypeExpressionConverter;
 
 /// <summary>
 /// Provides a thread-safe, static cache for attribute-based member mappings.
-/// This is an internal detail to improve performance by avoiding repeated reflection.
+/// This cache uses MemoryCache to prevent unbounded growth and potential memory leaks
+/// in long-running applications by setting a size limit and an eviction policy.
 /// </summary>
-internal sealed class MemberMappingCache
+internal static class MemberMappingCache
 {
-    private static readonly ConcurrentDictionary<MemberInfo, string?> Cache = new();
+    private static readonly MemoryCache Cache = new(
+        new MemoryCacheOptions
+        {
+            // Sets a limit on the number of entries in the cache.
+            // Adjust this value based on the expected number of unique MemberInfo entries.
+            SizeLimit = 1000,
+
+            // When the size limit is reached, this percentage of the cache is removed.
+            CompactionPercentage = 0.2
+        });
+
+    private static readonly MemoryCacheEntryOptions CacheEntryOptions = new MemoryCacheEntryOptions()
+        // Each entry is given a size of 1. This allows the SizeLimit to function as an item count.
+        .SetSize(1)
+        // Sets a sliding expiration policy. The entry will be evicted if it hasn't been accessed
+        // for this duration. This helps remove stale entries that are no longer in use.
+        .SetSlidingExpiration(TimeSpan.FromMinutes(30));
+
 
     /// <summary>
-    /// Gets the mapped destination member name for a given source member, using the cache.
-    /// <summary>
-    /// Retrieves the destination member name mapped to the specified member, using a cached value if available.
+    /// Retrieves the destination member name mapped to the specified member via the MapsToAttribute,
+    /// using a cached value if available.
     /// </summary>
     /// <param name="member">The source member for which to retrieve the mapped destination member name.</param>
     /// <returns>The destination member name if a mapping exists; otherwise, null.</returns>
     public static string? GetMapping(MemberInfo member)
     {
-        return Cache.GetOrAdd(member, static m => 
-            m.GetCustomAttribute<MapsToAttribute>(true)?.DestinationMemberName);
+        // GetOrCreate attempts to retrieve the value from the cache.
+        // If the key is not found, the factory delegate is executed to create the value,
+        // which is then added to the cache with the specified options and returned.
+        return Cache.GetOrCreate(member, entry =>
+        {
+            entry.SetOptions(CacheEntryOptions);
+            return member.GetCustomAttribute<MapsToAttribute>(true)?.DestinationMemberName;
+        });
     }
 }

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.5.0
+Install-Package CrossTypeExpressionConverter -Version 0.5.1
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.5.0
+dotnet add package CrossTypeExpressionConverter --version 0.5.1
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.5.1
+Install-Package CrossTypeExpressionConverter -Version 0.5.2
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.5.1
+dotnet add package CrossTypeExpressionConverter --version 0.5.2
 ```
 
 ---

--- a/Temp-Badgets-Helper.md
+++ b/Temp-Badgets-Helper.md
@@ -4,7 +4,7 @@
 [![SonarCloud Quality Gate](https://img.shields.io/sonar/quality_gate/scherenhaenden_CrossTypeExpressionConverter?server=https%3A%2F%2Fsonarcloud.io\&style=flat-square)](https://sonarcloud.io/summary/new_code?id=scherenhaenden_CrossTypeExpressionConverter)
 [![SonarCloud Bugs](https://img.shields.io/sonar/bugs/scherenhaenden_CrossTypeExpressionConverter?server=https%3A%2F%2Fsonarcloud.io\&style=flat-square)](https://sonarcloud.io/project/issues?id=scherenhaenden_CrossTypeExpressionConverter&resolved=false&types=BUG)
 [![SonarCloud Coverage](https://img.shields.io/sonar/coverage/scherenhaenden_CrossTypeExpressionConverter?server=https%3A%2F%2Fsonarcloud.io\&style=flat-square)](https://sonarcloud.io/component_measures?id=scherenhaenden_CrossTypeExpressionConverter&metric=coverage)
-[![CodeFactor](https://www.codefactor.io/repository/github/scherenhaenden/crosstypeexpressionconverter/badge?style=flat-square)](https://www.codefactor.io/repository/github/scherenhaenden/crosstypeexpressionconverter)
+
 [![GitHub last commit](https://img.shields.io/github/last-commit/scherenhaenden/CrossTypeExpressionConverter?style=flat-square)](https://github.com/scherenhaenden/CrossTypeExpressionConverter/commits/master)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/scherenhaenden/CrossTypeExpressionConverter?style=flat-square)](https://github.com/scherenhaenden/CrossTypeExpressionConverter/graphs/commit-activity)
 [![GitHub repo size](https://img.shields.io/github/repo-size/scherenhaenden/CrossTypeExpressionConverter?style=flat-square)](https://github.com/scherenhaenden/CrossTypeExpressionConverter)

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,13 +62,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.5.1
+Install-Package CrossTypeExpressionConverter -Version 0.5.2
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.5.1
+dotnet add package CrossTypeExpressionConverter --version 0.5.2
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,13 +62,13 @@ Stop rewriting similar filter logic for different types! `CrossTypeExpressionCon
 You can install `CrossTypeExpressionConverter` via NuGet Package Manager:
 
 ```shell
-Install-Package CrossTypeExpressionConverter -Version 0.5.0
+Install-Package CrossTypeExpressionConverter -Version 0.5.1
 ```
 
 Or using the .NET CLI:
 
 ```shell
-dotnet add package CrossTypeExpressionConverter --version 0.5.0
+dotnet add package CrossTypeExpressionConverter --version 0.5.1
 ```
 
 ---


### PR DESCRIPTION
## Summary by Sourcery

Implement a thread-safe, memory-bound cache for attribute-based member mappings, update the Visitor to leverage this cache with improved documentation, and refresh package version guidance in the docs.

New Features:
- Introduce MemberMappingCache to cache MapsTo attribute lookups with size limits and expiration policies

Enhancements:
- Refactor Visitor to use the centralized cache instead of inline mapping logic and enrich its XML documentation

Documentation:
- Bump NuGet installation instructions in README files to version 0.5.1
- Remove outdated CodeFactor badge from project docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved performance for attribute-based member mapping through the introduction of a memory caching mechanism.

* **Documentation**
  * Updated installation instructions in documentation to reference version 0.5.2.
  * Removed the CodeFactor badge from badge listings.
  * Enhanced XML documentation for certain internal methods and constructors.

* **Chores**
  * Updated project metadata and dependencies to version 0.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Update the package version to 0.5.2, refactor the member mapping logic to use a new `MemberMappingCache` class, and enhance documentation and comments across several files.

### Why are these changes being made?
These changes introduce a version bump that reflects updates including improved member-mapping performance via a static cache to optimize lookups, which helps in long-running applications. Documentation and comments were enhanced for better clarity and maintenance, ensuring correct installation references and codebase understanding.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->